### PR TITLE
Add `grpc.server.port` property.

### DIFF
--- a/src/main/java/nl/surf/polynsi/soap/connection/provider/ConnectionServiceProviderPortImpl.java
+++ b/src/main/java/nl/surf/polynsi/soap/connection/provider/ConnectionServiceProviderPortImpl.java
@@ -221,6 +221,11 @@ public class ConnectionServiceProviderPortImpl implements ConnectionProviderPort
                             pbP2PServiceBuilder.setDirectionality(directionality);
                         }
 
+                        /*  TODO Need to test each of the following SOAP elements for null. As some might not be set
+                            in case of an Reserve message update. An update generally only specifies a subset. Eg
+                            the initial Reservation included the wrong bandwidth. The update Reserve message will then
+                            only specifies the bandwidth (with the correct value).
+                         */
                         pbP2PServiceBuilder.setSymmetricPath(soapP2PService.isSymmetricPath())
                                 .setSourceStp(soapP2PService.getSourceSTP()).setDestStp(soapP2PService.getDestSTP());
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,10 @@ cxf.path=/soap
 soap.server.connection_provider.path=/connection/provider
 soap.server.connection_requester.path=/connection/requester
 
+# The port PolyNSI is listening on
+grpc.server.port=9090
+
+# The address and port SuPA is listening on.
 grpc.client.connection_provider.address=static://localhost:50051
 grpc.client.connection_provider.negotiationType=PLAINTEXT
 


### PR DESCRIPTION
We need to be explicit about the port we want the gRPC server to run on.